### PR TITLE
Replace yarl with urllib.parse

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,3 @@ Sphinx==2.4.4
 sphinx-autodoc-typehints
 sphinx-material==0.0.23
 typed_ast
-yarl>=1.4.2,<2

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ keywords =
 include_package_data = True
 install_requires =
     pamqp>=3.0.0a6,<4
-    yarl>=1.4.2,<2
 packages =
     aiorabbit
 zip_safe = true


### PR DESCRIPTION
**What**
Replace yarl with urllib.parse. Also move parsing of the url to `__init__` to avoid parsing/defaulting upon connection/reconnection.

**Why** 
The standard library is sufficient - no need for an external dependency.
