### PR TITLE
Put a Lock around the client close method

### DIFF
--- a/tests/test_client_edge_cases.py
+++ b/tests/test_client_edge_cases.py
@@ -36,6 +36,14 @@ class ClientCloseTestCase(testing.ClientTestCase):
         await self.client.close()
         self.assertTrue(self.client.is_closed)
 
+    @testing.async_test
+    async def test_contemporaneous_double_close(self):
+        await self.connect()
+        await asyncio.gather(
+            self.client.close(),
+            self.client.close())
+        self.assertTrue(self.client.is_closed)
+
 
 class ChannelRotationTestCase(testing.ClientTestCase):
 


### PR DESCRIPTION
If `close()` is called while another `close()` is already running, it will crash on a closed `channel0` trying to close itself again:

```
Traceback (most recent call last):
  File "/usr/lib/python3.9/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.9/unittest/case.py", line 593, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/home/kvance/projects/aiorabbit/tests/testing.py", line 20, in wrapper
    loop.run_until_complete(func[0](*args, **kwargs))
  File "/usr/lib/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/kvance/projects/aiorabbit/tests/test_client_edge_cases.py", line 42, in test_contemporaneous_double_close
    await asyncio.gather(
  File "/home/kvance/projects/aiorabbit/aiorabbit/client.py", line 434, in close
    await self._close()
  File "/home/kvance/projects/aiorabbit/aiorabbit/client.py", line 1382, in _close
    await self._channel0.close()
  File "/home/kvance/projects/aiorabbit/aiorabbit/channel0.py", line 187, in close
    self._heartbeat_timer.cancel()
AttributeError: 'NoneType' object has no attribute 'cancel'
```