### PR TITLE
Fix infinite hang upon invalid state transition

### DIFF
--- a/aiorabbit/state.py
+++ b/aiorabbit/state.py
@@ -81,9 +81,11 @@ class StateManager:
             return
         elif value != STATE_EXCEPTION \
                 and value not in self.STATE_TRANSITIONS[self._state]:
-            raise exceptions.StateTransitionError(
+            exc = exceptions.StateTransitionError(
                 'Invalid state transition from {!r} to {!r}'.format(
                     self.state, self.state_description(value)))
+            self._exception = exc
+            raise exc
         self._logger.debug(
             'Transition to %i: %s from %i: %s after %.4f seconds',
             value, self.state_description(value),

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -55,6 +55,8 @@ class TestCase(testing.AsyncTestCase):
         self.assert_state(state.STATE_UNINITIALIZED)
         with self.assertRaises(exceptions.StateTransitionError):
             self.obj.set_state(STATE_BAZ)
+        self.assertIsInstance(self.obj._exception,
+                              exceptions.StateTransitionError)
 
     def test_setting_state_to_same_value(self):
         self.assert_state(state.STATE_UNINITIALIZED)


### PR DESCRIPTION
Resolves https://github.com/gmr/aiorabbit/issues/12
**Previous**:
The client would hang indefinitely when attempting to publish after an `InvalidStateTransition` exception was raised. 
The hang is caused by an infinite loop which should break when `self._exception` is set: https://github.com/gmr/aiorabbit/blob/bd4005d3b564d38fc986c9cee10329395134c8ab/aiorabbit/state.py#L111-L119

**New**:
The `InvalidStateTransition` exception is raised to the publish method. Although the client then remains in an usable state, this change allows for one to catch the exception and manually restart the client.

With this change, the following happens:
```
DEBUG:aiorabbit.channel0:Waiter 35805399524094 wait on 22: OpenOk Received has finished [None]
DEBUG:aiorabbit.channel0:Checking for heartbeats every 60.000000 seconds
DEBUG:aiorabbit.client:Set state to 20: Opened while state is 19: Connected - {36: {}, 34: {}} [None]
DEBUG:aiorabbit.client:Transition to 20: Opened from 19: Connected after 0.0031 seconds
DEBUG:aiorabbit.client:Set state to 23: Opening Channel while state is 20: Opened - {36: {}, 34: {}} [None]
DEBUG:aiorabbit.client:Transition to 23: Opening Channel from 20: Opened after 0.0000 seconds
DEBUG:aiorabbit.client:Set state to 32: Channel Requested while state is 23: Opening Channel - {36: {}, 34: {}} [None]
DEBUG:aiorabbit.client:Transition to 32: Channel Requested from 23: Opening Channel after 0.0001 seconds
DEBUG:aiorabbit.client:Set state to 33: Channel Open while state is 32: Channel Requested - {36: {}, 34: {}} [None]
DEBUG:aiorabbit.client:Transition to 33: Channel Open from 32: Channel Requested after 0.0003 seconds
Traceback (most recent call last):
  File "/home/ar/code/github/gmr/aiorabbit/reproduce_does_not_reconnect.py", line 37, in <module>
    asyncio.run(main())
  File "/usr/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/ar/code/github/gmr/aiorabbit/reproduce_does_not_reconnect.py", line 21, in main
    async with aiorabbit.connect(URL) as client:
  File "/usr/lib/python3.10/contextlib.py", line 206, in __aexit__
    await anext(self.gen)
  File "/home/ar/code/github/gmr/aiorabbit/aiorabbit/__init__.py", line 46, in connect
    await rmq_client.close()
  File "/home/ar/code/github/gmr/aiorabbit/aiorabbit/client.py", line 433, in close
    await self._send_rpc(
  File "/home/ar/code/github/gmr/aiorabbit/aiorabbit/client.py", line 1649, in _send_rpc
    return await self._post_wait_on_state(result, exc, True)
  File "/home/ar/code/github/gmr/aiorabbit/aiorabbit/client.py", line 1598, in _post_wait_on_state
    raise exceptions.CLASS_MAPPING[err[0]](err[1])
KeyError: 0
```