### PR TITLE
Fix flakey test

### DIFF
--- a/tests/test_client_edge_cases.py
+++ b/tests/test_client_edge_cases.py
@@ -108,7 +108,7 @@ class TimeoutOnConnectTestCase(testing.ClientTestCase):
 
     def setUp(self) -> None:
         self._old_uri = os.environ['RABBITMQ_URI']
-        os.environ['RABBITMQ_URI'] = '{}?connection_timeout=0.001'.format(
+        os.environ['RABBITMQ_URI'] = '{}?connection_timeout=0.000001'.format(
             os.environ['RABBITMQ_URI'])
         super().setUp()
 


### PR DESCRIPTION
One of my machines is apparently fast enough where the previous timeout of 0.001 is
good enough to sometimes establish a connection. Particularly noticed
this when running `python -m unittest tests.test_client_edge_cases
-bfv`. I did not encounter flakeyness when running `coverage run`.