### PR TITLE
Map heartbeat-timeout reply code (599) to ConnectionClosedException

### DIFF
--- a/aiorabbit/exceptions.py
+++ b/aiorabbit/exceptions.py
@@ -244,5 +244,6 @@ CLASS_MAPPING = {
     506: ResourceError,
     530: NotAllowed,
     540: NotImplemented,
-    541: InternalError
+    541: InternalError,
+    599: ConnectionClosedException,
 }

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,27 @@
+import unittest
+
+from aiorabbit import exceptions
+
+
+class ClassMappingTestCase(unittest.TestCase):
+    """Exercise the AMQP reply-code to exception class mapping."""
+
+    def test_known_amqp_reply_code_maps_to_concrete_exception(self):
+        self.assertIs(exceptions.CLASS_MAPPING[404], exceptions.NotFound)
+
+    def test_heartbeat_timeout_maps_to_connection_closed(self):
+        # Channel0._heartbeat_check synthesises reply code 599 when the broker
+        # stops sending heartbeats. Client._on_remote_close translates that to
+        # ConnectionClosedException directly, but the same code is later
+        # re-translated by Client.publish and Client._post_wait_on_state via
+        # CLASS_MAPPING. Without an explicit entry those sites fall back to
+        # UnknownError, which loses the semantic that the connection has been
+        # closed.
+        self.assertIs(
+            exceptions.CLASS_MAPPING[599],
+            exceptions.ConnectionClosedException)
+
+    def test_unmapped_reply_code_falls_back_to_unknown_error(self):
+        self.assertIs(
+            exceptions.CLASS_MAPPING.get(999, exceptions.UnknownError),
+            exceptions.UnknownError)


### PR DESCRIPTION
## Summary
- Channel0._heartbeat_check synthesises reply code 599 when the broker stops sending heartbeats, and Client._on_remote_close already routes 599 to ConnectionClosedException — but the same code is re-translated by Client.publish and Client._post_wait_on_state via CLASS_MAPPING.get(err[0], UnknownError), so those sites fall back to UnknownError and mask the connection-close semantics.
- Register 599 -> ConnectionClosedException in exceptions.CLASS_MAPPING so the downstream lookup sites raise the same exception that _on_remote_close already raises.
- Add a small unit test covering the new mapping (and pin the UnknownError fallback for genuinely unmapped codes).

Fixes #22, follow-up to #19 / #21.

## Test plan
- [x] `python -m unittest tests.test_exceptions tests.test_channel0` — passes
- [x] Full suite via `./bootstrap` + `python -m unittest discover` — 144/146 pass. The two failing tests (`test_exchange_declare_invalid_exchange_type`, `test_confirm_select_already_invoked_on_reconnect`) reproduce on `main` without this change; they expect `PreconditionFailed` but RabbitMQ 3.11+ returns `COMMAND_INVALID`. Unrelated to this PR.
- [x] `flake8 aiorabbit tests` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error code 541 mapping to properly handle internal errors.

* **New Features**
  * Added support for error code 599 to handle connection closed exceptions in heartbeat timeout scenarios.

* **Tests**
  * Added test coverage for exception mappings and fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/aiorabbit/pull/23?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->